### PR TITLE
Inject required args only into plugins config

### DIFF
--- a/autogpt/config/config.py
+++ b/autogpt/config/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import contextlib
 import os
 import re
-from typing import Dict
+from typing import Dict, Union
 
 import yaml
 from colorama import Fore
@@ -82,11 +82,6 @@ class Config(SystemSettings):
     elevenlabs_voice_id: Optional[str] = None
     plugins: list[str]
     authorise_key: str
-
-    # Executed immediately after init by Pydantic
-    def model_post_init(self, **kwargs) -> None:
-        if not self.plugins_config.plugins:
-            self.plugins_config = PluginsConfig.load_config(self)
 
 
 class ConfigBuilder(Configurable[Config]):
@@ -206,21 +201,16 @@ class ConfigBuilder(Configurable[Config]):
             "chat_messages_enabled": os.getenv("CHAT_MESSAGES_ENABLED") == "True",
         }
 
-        # Converting to a list from comma-separated string
-        disabled_command_categories = os.getenv("DISABLED_COMMAND_CATEGORIES")
-        if disabled_command_categories:
-            config_dict[
-                "disabled_command_categories"
-            ] = disabled_command_categories.split(",")
+        config_dict["disabled_command_categories"] = _safe_split(
+            os.getenv("DISABLED_COMMAND_CATEGORIES")
+        )
 
-        # Converting to a list from comma-separated string
-        shell_denylist = os.getenv("SHELL_DENYLIST", os.getenv("DENY_COMMANDS"))
-        if shell_denylist:
-            config_dict["shell_denylist"] = shell_denylist.split(",")
-
-        shell_allowlist = os.getenv("SHELL_ALLOWLIST", os.getenv("ALLOW_COMMANDS"))
-        if shell_allowlist:
-            config_dict["shell_allowlist"] = shell_allowlist.split(",")
+        config_dict["shell_denylist"] = _safe_split(
+            os.getenv("SHELL_DENYLIST", os.getenv("DENY_COMMANDS"))
+        )
+        config_dict["shell_allowlist"] = _safe_split(
+            os.getenv("SHELL_ALLOWLIST", os.getenv("ALLOW_COMMANDS"))
+        )
 
         config_dict["google_custom_search_engine_id"] = os.getenv(
             "GOOGLE_CUSTOM_SEARCH_ENGINE_ID", os.getenv("CUSTOM_SEARCH_ENGINE_ID")
@@ -230,13 +220,13 @@ class ConfigBuilder(Configurable[Config]):
             "ELEVENLABS_VOICE_ID", os.getenv("ELEVENLABS_VOICE_1_ID")
         )
 
-        plugins_allowlist = os.getenv("ALLOWLISTED_PLUGINS")
-        if plugins_allowlist:
-            config_dict["plugins_allowlist"] = plugins_allowlist.split(",")
-
-        plugins_denylist = os.getenv("DENYLISTED_PLUGINS")
-        if plugins_denylist:
-            config_dict["plugins_denylist"] = plugins_denylist.split(",")
+        config_dict["plugins_allowlist"] = _safe_split(os.getenv("ALLOWLISTED_PLUGINS"))
+        config_dict["plugins_denylist"] = _safe_split(os.getenv("DENYLISTED_PLUGINS"))
+        config_dict["plugins_config"] = PluginsConfig.load_config(
+            config_dict["plugins_config_file"],
+            config_dict["plugins_denylist"],
+            config_dict["plugins_allowlist"],
+        )
 
         with contextlib.suppress(TypeError):
             config_dict["image_size"] = int(os.getenv("IMAGE_SIZE"))
@@ -318,3 +308,10 @@ def check_openai_api_key(config: Config) -> None:
         else:
             print("Invalid OpenAI API key!")
             exit(1)
+
+
+def _safe_split(s: Union[str, None], sep: str = ",") -> list[str]:
+    """Split a string by a separator. Return an empty list if the string is None."""
+    if s is None:
+        return []
+    return s.split(sep)

--- a/autogpt/core/configuration/schema.py
+++ b/autogpt/core/configuration/schema.py
@@ -49,14 +49,7 @@ class Configurable(abc.ABC, Generic[S]):
         defaults = cls.default_settings.dict()
         final_configuration = deep_update(defaults, configuration)
 
-        config_obj = cls.default_settings.__class__.parse_obj(final_configuration)
-
-        if hasattr(config_obj, "model_post_init"):
-            # HOTFIX: Call model_post_init explictly as it doesn't seem to be called for pydantic<2.0.0
-            # https://github.com/pydantic/pydantic/issues/1729#issuecomment-1300576214
-            config_obj.model_post_init()
-
-        return config_obj
+        return cls.default_settings.__class__.parse_obj(final_configuration)
 
 
 def _get_user_config_fields(instance: BaseModel) -> dict[str, Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,11 @@ def config(
     # avoid circular dependency
     from autogpt.plugins.plugins_config import PluginsConfig
 
-    config.plugins_config = PluginsConfig.load_config(global_config=config)
+    config.plugins_config = PluginsConfig.load_config(
+        plugins_config_file=config.plugins_config_file,
+        plugins_denylist=config.plugins_denylist,
+        plugins_allowlist=config.plugins_allowlist,
+    )
 
     # Do a little setup and teardown since the config object is a singleton
     mocker.patch.multiple(

--- a/tests/unit/test_plugins.py
+++ b/tests/unit/test_plugins.py
@@ -70,7 +70,11 @@ def test_create_base_config(config: Config):
     config.plugins_denylist = ["c", "d"]
 
     os.remove(config.plugins_config_file)
-    plugins_config = PluginsConfig.load_config(global_config=config)
+    plugins_config = PluginsConfig.load_config(
+        plugins_config_file=config.plugins_config_file,
+        plugins_denylist=config.plugins_denylist,
+        plugins_allowlist=config.plugins_allowlist,
+    )
 
     # Check the structure of the plugins config data
     assert len(plugins_config.plugins) == 4
@@ -102,7 +106,11 @@ def test_load_config(config: Config):
         f.write(yaml.dump(test_config))
 
     # Load the config from disk
-    plugins_config = PluginsConfig.load_config(global_config=config)
+    plugins_config = PluginsConfig.load_config(
+        plugins_config_file=config.plugins_config_file,
+        plugins_denylist=config.plugins_denylist,
+        plugins_allowlist=config.plugins_allowlist,
+    )
 
     # Check that the loaded config is equal to the test config
     assert len(plugins_config.plugins) == 2


### PR DESCRIPTION
### Background



### Changes
- Add a `_safe_split` function to reduce some repeated code
- Inject only the required arguments into the plugin config so we don't need to wait on any complex state initialization
- initialize the plugin config when we're initializing the rest of the `Config` arguments so we're not doing special case ordering.

### Documentation
<!-- Explain how your changes are documented, such as in-code comments or external documentation. Ensure that the documentation is clear, concise, and easy to understand. -->

### Test Plan
<!-- Describe how you tested this functionality. Include steps to reproduce, relevant test cases, and any other pertinent information. -->

### PR Quality Checklist
- [x] My pull request is atomic and focuses on a single change.
- [ ] I have thoroughly tested my changes with multiple different prompts.
- [x] I have considered potential risks and mitigations for my changes.
- [x] I have documented my changes clearly and comprehensively.
- [x] I have not snuck in any "extra" small tweaks changes. <!-- Submit these as separate Pull Requests, they are the easiest to merge! -->
- [x] I have run `black .` and `isort .` against my code to ensure it passes our linter.

<!-- If you haven't added tests, please explain why. If you have, check the appropriate box. If you've ensured your PR is atomic and well-documented, check the corresponding boxes. -->

<!-- By submitting this, I agree that my pull request should be closed if I do not fill this out or follow the guidelines. -->
